### PR TITLE
Fix conflict between fatiando=0.5 and numpy=1.13

### DIFF
--- a/code/tesseroid_density/setup.py
+++ b/code/tesseroid_density/setup.py
@@ -1,4 +1,9 @@
+"""
+Use Cython to build the C extension and compile it into a Python module.
+"""
 from distutils.core import setup
 from Cython.Build import cythonize
+import numpy
 
-setup(ext_modules = cythonize("_tesseroid.pyx"))
+setup(ext_modules=cythonize("_tesseroid.pyx"),
+      include_dirs=[numpy.get_include()])

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
     - python=2.7
     - future=0.16.0
-    - numpy=1.13.3
+    - numpy=1.11.*
     - scipy=0.19.1
     - sympy=1.1.1
     - matplotlib=2.1.0


### PR DESCRIPTION
Need to use numpy 1.11 with Fatiando to avoid conflicts between the
conda packages. The pip installed version should work but it's a huge
pain under windows.

Include the numpy headers in the setup.py file to guarantee that the
compiler will find them.