### PR TITLE
Efficient density discretization

### DIFF
--- a/code/tesseroid_density/tesseroid.py
+++ b/code/tesseroid_density/tesseroid.py
@@ -267,6 +267,7 @@ def _density_based_discretization(bounds, density, delta):
     w, e, s, n, top, bottom = bounds[:]
     if top < bottom:
         top, bottom = bottom, top
+    tesseroid_size = top - bottom
     pending, subset = [bounds], []
 
     # Compute maximum and minimum density for future normalization
@@ -298,7 +299,8 @@ def _density_based_discretization(bounds, density, delta):
             warnings.warn(msg, RuntimeWarning)
             continue
 
-        if max_diff > delta:
+        size_ratio = (top - bottom)/tesseroid_size
+        if max_diff*size_ratio > delta:
             pending.append([w, e, s, n, top, divider])
             pending.append([w, e, s, n, divider, bottom])
         else:


### PR DESCRIPTION
Fixes #16 and incorporates discretized tesseroid size ratio in discretization equation.

From the linear density analysis we can conclude that the quadrature approximates any density function as it were linear. In that case, the density-based discretization could be thought as a picewise linear approximation of the density function.

There are [some algorithms](https://optimization.mccormick.northwestern.edu/index.php/Piecewise_linear_approximation) to obtain the optimal picewise linear approximation of convex functions, but the problem with those is that the number of points (or discretizations in our case) must be an input. This may be a problem in our scenario, due to the fact that besides a good enough approximation we need it to be time efficient, i.e. get a good approximation by minimizing the number of discretizations.

That's why I think that our proposed density-based discretization solves in a better way our needs. But, I've seen that asking to minimize only the maximum difference between the normalized density and the reference straight line is not enough.

Firstly, as seen in #16, a single normalization at the beginning of the discretization is sufficient, and it also reduces the number of unneeded discretizations.

Secondly, due to the fact that small tesseroids do not contribute to the numerical approximation as big ones do, I propose to take into account the ratio of the discretized tesseroid and the size of the original tesseroid in the discretization inequality:

![imagen](https://user-images.githubusercontent.com/11541317/37470391-3984aeea-2846-11e8-9a89-7302703d4e3d.png)

where L_r is the vertical size of the original tesseroid that is being discretized, while L_r^{small} is the vertical size of the discretized tesseroid that is being analysed.

This modification makes that for two intervals with the same max{\rho_n(r') - \rho_l(r')}, only the bigger interval may be subdivided, due to the fact that it will probably introduce more error into the gravity field computation.

In order to show the difference between the current algorithm in 98f3b1fea07829ba1a504f61e5feace2cd4af3f7 and the new one in cc19bace9f60e8101985ee6a319415fbc2614eec lets run the following code:

```python
from __future__ import print_function, division

import numpy as np
import matplotlib.pyplot as plt
# This is our custom tesseroid code
from tesseroid_density import tesseroid

w, e, s, n, top, bottom = -10, 10, -10, 10, 0, -35000
bounds = [w, e, s, n, top, bottom]

def density_exponential(height):
    rho0, rho1 = 2670, 3300
    a = (rho1 - rho0)/(np.exp((abs(top - bottom))/b) - 1)
    c = rho0 - a
    return a*np.exp(-height/b) + c

delta = 0.02
# delta = 0.2
colors = ["C" + str(i) for i in range(7)]

for b, color in zip([1e3, 1e4, 2e4, 1e5], colors):
    subset = tesseroid._density_based_discretization(bounds,
                                           density_exponential,
                                           delta)

    dividers = [bound[-1] for bound in subset]
    dividers.sort()
    dividers.append(top)
    dividers = np.array(dividers)

    heights = np.linspace(bottom, top, 101)
    densities = density_exponential(heights)
    rho_min, rho_max = densities.min(), densities.max()

    plt.plot(heights, densities, linewidth=3, color=color)
    plt.plot(dividers, density_exponential(dividers),
             'o-', linewidth=1, color=color)
plt.show()
```

Produces the following discretizations:

* For the current algorithm (delta=0.2):
![imagen](https://user-images.githubusercontent.com/11541317/37471069-b4e7e10a-2847-11e8-8c36-861af02dc52e.png)

* For the modified version in this PR (delta=0.02):
![imagen](https://user-images.githubusercontent.com/11541317/37471107-c7c5990c-2847-11e8-9321-697cd6d05e14.png)

Observation: the delta values between the two methods are not related.

The new algorithm produces much less discretizations for highly varying functions, while for the other functions the discretization seems more reliable.