### PR TITLE
Remove install instructions on code/tesseroid_density/README.md

### DIFF
--- a/code/tesseroid_density/README.md
+++ b/code/tesseroid_density/README.md
@@ -13,20 +13,6 @@ Here we can find the source code for the gravity fields computation.
     They are no intended to be used by the user. Call the `tesseroid.py`
     functions instead.
 
-* `Makefile`:
-    File to automate the compilation of the `tesseroid.pyx` code.
-
 ## How to Compile
 
-Run the following command:
-
-```
-make
-```
-
-## Requirements
-
-You'll need a C compiler installed in order to build the Cython module.
-On Linux, gcc should be installed by default.
-On Windows, you'll need to install the Microsoft compiler for Python 2.7
-(download at http://aka.ms/vcpython27).
+Instructions on `code/README.md`.


### PR DESCRIPTION
The `code/tesseroid_density/README.md` contained instructions on how to
install the package using a inexistent Makefile. The `tesseroid_density`
package must be installed through the `code/Makefile`, following the
instructions under `code/setup.py`.

Caught on #73.